### PR TITLE
Keep events on site until they end

### DIFF
--- a/functions/getEvents/getEvents.js
+++ b/functions/getEvents/getEvents.js
@@ -20,11 +20,7 @@ exports.handler = async (event, context) => {
         )}`.toLowerCase()
         return event
       })
-      .filter((event) => {
-        const compared = compareAsc(event.endDatetime, Date.now())
-        console.log(compared)
-        return compared > -1
-      })
+      .filter((event) => compareAsc(event.endDatetime, Date.now()) > -1)
       .sort((a, b) => compareAsc(a.startDatetime, b.startDatetime))
       .map((event) => {
         const start = format(event.startDatetime, "yyyyMMdd'T'HHmmSS")

--- a/functions/getEvents/getEvents.js
+++ b/functions/getEvents/getEvents.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch')
 const { format, compareAsc } = require('date-fns')
 
-let endpoint =
-  'https://v2-api.sheety.co/7d5818822fb2e8bc71945c59d529166f/yaleEvents/events'
+const endpoint =
+  'https://api.sheety.co/9a19cc691e17a75dcd0a6f68b6d7c2d8/yalePublicCalendar/events'
 
 exports.handler = async (event, context) => {
   try {
@@ -20,7 +20,11 @@ exports.handler = async (event, context) => {
         )}`.toLowerCase()
         return event
       })
-      .filter((event) => compareAsc(event.endDatetime, Date.now()) > 0)
+      .filter((event) => {
+        const compared = compareAsc(event.endDatetime, Date.now())
+        console.log(compared)
+        return compared > -1
+      })
       .sort((a, b) => compareAsc(a.startDatetime, b.startDatetime))
       .map((event) => {
         const start = format(event.startDatetime, "yyyyMMdd'T'HHmmSS")

--- a/index.html
+++ b/index.html
@@ -459,7 +459,7 @@
 				obj[key] = value
 			})
 
-			return fetch('https://v2-api.sheety.co/7d5818822fb2e8bc71945c59d529166f/yaleEvents/events', {
+			return fetch('https://api.sheety.co/9a19cc691e17a75dcd0a6f68b6d7c2d8/yalePublicCalendar/events', {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Yale-Public-Calendar",
+  "name": "yale-public-calendar",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
- update sheety endpoint to the new account created by @nickmassarelli 
- fix end datetime comparison to current time so now events are visible on the site until they actually end (turns out all this took was changing a 0 to a -1 lol)